### PR TITLE
O3:1440 - Setup cron job for the test workflows and simplify the script runner

### DIFF
--- a/.github/workflows/refapp-3x-login.yml
+++ b/.github/workflows/refapp-3x-login.yml
@@ -1,7 +1,7 @@
 name: RefApp 3.x Login
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 */12 * * *"
   push:
     branches: [ main ]
   pull_request:

--- a/.github/workflows/refapp-3x-login.yml
+++ b/.github/workflows/refapp-3x-login.yml
@@ -1,5 +1,7 @@
 name: RefApp 3.x Login
 on:
+  schedule:
+    - cron: "0 0 * * *"
   push:
     branches: [ main ]
   pull_request:

--- a/.github/workflows/refapp-3x-patient-registration.yml
+++ b/.github/workflows/refapp-3x-patient-registration.yml
@@ -1,7 +1,7 @@
 name: RefApp 3.x Patient Registration
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 */12 * * *"
   push:
     branches: [ main ]
   pull_request:

--- a/.github/workflows/refapp-3x-patient-registration.yml
+++ b/.github/workflows/refapp-3x-patient-registration.yml
@@ -1,5 +1,7 @@
 name: RefApp 3.x Patient Registration
 on:
+  schedule:
+    - cron: "0 0 * * *"
   push:
     branches: [ main ]
   pull_request:

--- a/.github/workflows/refapp-3x-patient-search.yml
+++ b/.github/workflows/refapp-3x-patient-search.yml
@@ -1,5 +1,7 @@
 name: RefApp 3.x Patient Search
 on:
+  schedule:
+    - cron: "0 0 * * *"
   push:
     branches: [ main ]
   pull_request:

--- a/.github/workflows/refapp-3x-patient-search.yml
+++ b/.github/workflows/refapp-3x-patient-search.yml
@@ -1,7 +1,7 @@
 name: RefApp 3.x Patient Search
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 */12 * * *"
   push:
     branches: [ main ]
   pull_request:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ ___
 [3.x Demo Build](https://ci.openmrs.org/browse/REFAPP-D3X) ![Build Status](https://ci.openmrs.org/plugins/servlet/wittified/build-status/REFAPP-D3X)
 [![RefApp 3.x Login](https://github.com/openmrs/openmrs-test-3refapp/actions/workflows/refapp-3x-login.yml/badge.svg)](https://github.com/openmrs/openmrs-test-3refapp/actions/workflows/refapp-3x-login.yml)
 [![RefApp 3.x Patient Registration](https://github.com/openmrs/openmrs-test-3refapp/actions/workflows/refapp-3x-patient-registration.yml/badge.svg)](https://github.com/openmrs/openmrs-test-3refapp/actions/workflows/refapp-3x-patient-registration.yml)
+[![RefApp 3.x Patient Search](https://github.com/openmrs/openmrs-test-3refapp/actions/workflows/refapp-3x-patient-search.yml/badge.svg)](https://github.com/openmrs/openmrs-test-3refapp/actions/workflows/refapp-3x-patient-search.yml)
 ___
 
 

--- a/cypress/integration/cucumber/step_definitions/refapp-3.x/01-login/login.js
+++ b/cypress/integration/cucumber/step_definitions/refapp-3.x/01-login/login.js
@@ -1,8 +1,8 @@
 import {Given} from 'cypress-cucumber-preprocessor/steps';
 
-beforeEach("Take a dump of the database and restore",() => {
+beforeEach("Restore Database",() => {
     //Run the script using npm
-    cy.exec("npm run resetDB")
+    cy.exec("bash scripts/resetDB.sh  ")
 })
 
 Given('user arrives at the login page', () => {

--- a/cypress/integration/cucumber/step_definitions/refapp-3.x/01-login/login.js
+++ b/cypress/integration/cucumber/step_definitions/refapp-3.x/01-login/login.js
@@ -1,8 +1,6 @@
 import {Given} from 'cypress-cucumber-preprocessor/steps';
 
 Given('user arrives at the login page', () => {
-    //Restore the database
-    cy.restoreDB();
     cy.visit('/login');
 })
 

--- a/cypress/integration/cucumber/step_definitions/refapp-3.x/01-login/login.js
+++ b/cypress/integration/cucumber/step_definitions/refapp-3.x/01-login/login.js
@@ -2,7 +2,7 @@ import {Given} from 'cypress-cucumber-preprocessor/steps';
 
 beforeEach("Restore Database",() => {
     //Run the script using npm
-    cy.exec("bash scripts/resetDB.sh  ")
+    cy.exec("bash scripts/resetDB.sh")
 })
 
 Given('user arrives at the login page', () => {

--- a/cypress/integration/cucumber/step_definitions/refapp-3.x/01-login/login.js
+++ b/cypress/integration/cucumber/step_definitions/refapp-3.x/01-login/login.js
@@ -1,15 +1,8 @@
 import {Given} from 'cypress-cucumber-preprocessor/steps';
 
-beforeEach("Restore Database",() => {
-    //Run the script using npm
-    cy.exec("bash scripts/resetDB.sh")
-})
-
 Given('user arrives at the login page', () => {
-    cy.on('uncaught:exception', (err, runnable) => {
-    	console.log(err);
-    	return false;
-    });
+    //Restore the database
+    cy.restoreDB();
     cy.visit('/login');
 })
 

--- a/cypress/integration/cucumber/step_definitions/refapp-3.x/02-patient-registration/patient-registration.js
+++ b/cypress/integration/cucumber/step_definitions/refapp-3.x/02-patient-registration/patient-registration.js
@@ -1,8 +1,6 @@
 import {Given} from 'cypress-cucumber-preprocessor/steps';
 
 Given('the user login to the Outpatient Clinic', () => {
-    //restore the database
-    cy.restoreDB();
     cy.login();
     cy.visit('home');
 })

--- a/cypress/integration/cucumber/step_definitions/refapp-3.x/02-patient-registration/patient-registration.js
+++ b/cypress/integration/cucumber/step_definitions/refapp-3.x/02-patient-registration/patient-registration.js
@@ -1,15 +1,8 @@
 import {Given} from 'cypress-cucumber-preprocessor/steps';
 
-beforeEach("Restore Database",() => {
-    //Run the script using npm
-    cy.exec("bash scripts/resetDB.sh   ")
-})
-
 Given('the user login to the Outpatient Clinic', () => {
-    cy.on('uncaught:exception', (err, runnable) => {
-    	console.log(err);
-    	return false;
-    });
+    //restore the database
+    cy.restoreDB();
     cy.login();
     cy.visit('home');
 })

--- a/cypress/integration/cucumber/step_definitions/refapp-3.x/02-patient-registration/patient-registration.js
+++ b/cypress/integration/cucumber/step_definitions/refapp-3.x/02-patient-registration/patient-registration.js
@@ -1,8 +1,8 @@
 import {Given} from 'cypress-cucumber-preprocessor/steps';
 
-beforeEach("Take a dump of the database and restore",() => {
+beforeEach("Restore Database",() => {
     //Run the script using npm
-    cy.exec("npm run resetDB")
+    cy.exec("bash scripts/resetDB.sh   ")
 })
 
 Given('the user login to the Outpatient Clinic', () => {

--- a/cypress/integration/cucumber/step_definitions/refapp-3.x/06-patient-search/patient-search.js
+++ b/cypress/integration/cucumber/step_definitions/refapp-3.x/06-patient-search/patient-search.js
@@ -2,9 +2,9 @@ import {Given} from 'cypress-cucumber-preprocessor/steps';
 
 let patient_uuid = null;
 
-beforeEach("Take a dump of the database and restore",() => {
+beforeEach("Restore Database",() => {
     //Run the script using npm
-    cy.exec("npm run resetDB")
+    cy.exec("bash scripts/resetDB.sh")
 })
 
 before({tags: '@patient-involved'}, () => {

--- a/cypress/integration/cucumber/step_definitions/refapp-3.x/06-patient-search/patient-search.js
+++ b/cypress/integration/cucumber/step_definitions/refapp-3.x/06-patient-search/patient-search.js
@@ -2,22 +2,15 @@ import {Given} from 'cypress-cucumber-preprocessor/steps';
 
 let patient_uuid = null;
 
-beforeEach("Restore Database",() => {
-    //Run the script using npm
-    cy.exec("bash scripts/resetDB.sh")
-})
-
 before({tags: '@patient-involved'}, () => {
     cy.createPatient().then((user) => {
         patient_uuid = user.uuid;
     });
 })
 
-Given('the user login to the Outpatient Clinic', () => {    
-    cy.on('uncaught:exception', (err, runnable) => {
-    	console.log(err);
-    	return false;
-    });
+Given('the user login to the Outpatient Clinic', () => {
+    //Restore the database
+    cy.restoreDB();
     cy.login();
     cy.visit('home');
 })

--- a/cypress/integration/cucumber/step_definitions/refapp-3.x/06-patient-search/patient-search.js
+++ b/cypress/integration/cucumber/step_definitions/refapp-3.x/06-patient-search/patient-search.js
@@ -9,8 +9,6 @@ before({tags: '@patient-involved'}, () => {
 })
 
 Given('the user login to the Outpatient Clinic', () => {
-    //Restore the database
-    cy.restoreDB();
     cy.login();
     cy.visit('home');
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -394,3 +394,6 @@ Cypress.Commands.add('deletePatient', (uuid) => {
     });
 });
 
+Cypress.Commands.add('restoreDB', () => {
+    cy.exec("bash scripts/resetDB.sh")
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -7,6 +7,11 @@ const ADMIN_PASSWORD = Cypress.env('ADMIN_PASSWORD');
 const DEFAULT_LOCATION_UUID = Cypress.env('DEFAULT_LOCATION_UUID');
 const TOKEN = window.btoa(`${ADMIN_USERNAME}:${ADMIN_PASSWORD}`);
 
+beforeEach("Restore database",() => {
+    //Run the script
+    cy.exec("bash scripts/resetDB.sh");
+})
+
 Cypress.Commands.add('runAndAwait', (callable, method='GET', addArtificialWait=false) => {
     const requestId = `apiRequest-${uuid()}`;
 
@@ -392,8 +397,4 @@ Cypress.Commands.add('deletePatient', (uuid) => {
             Authorization: `Basic ${TOKEN}`,
         },
     });
-});
-
-Cypress.Commands.add('restoreDB', () => {
-    cy.exec("bash scripts/resetDB.sh")
 });

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "refapp3PatientSearch": "cypress run --spec resources/features/refapp-3.x/06-patient-search/patient-search.feature",
     "refapp3Settings": "cypress run --spec resources/features/refapp-3.x/03-settings/settings.feature",
     "refapp3ClinicalVisit": "cypress run --spec resources/features/refapp-3.x/04-clinical-visit/clinical-visit.feature",
-    "refapp3VitalsAndTriage": "cypress run --spec resources/features/refapp-3.x/05-vitals-and-triage/vitals-and-triage.feature",
-    "resetDB" : "bash scripts/resetDB.sh"
+    "refapp3VitalsAndTriage": "cypress run --spec resources/features/refapp-3.x/05-vitals-and-triage/vitals-and-triage.feature"
   },
   "devDependencies": {
     "@testing-library/cypress": "^8.0.0",


### PR DESCRIPTION
## Purpose
The pull request is created to set up corn job for the GitHub workflows. it will run the GitHub workflows for a schedule (Twice a day). Also by this pr, the script running method will be simplified. And this pull request is related to the ticket number [O3-1440](https://issues.openmrs.org/browse/O3-1440)

## Goals.
- Make GitHub workflows run for a scheduled time.
- Simplified the restore DB script runner.

## Approach
 - Create a cron job feature for GitHub workflows.  (every 12 hours)  
 - Make script runner directly run by the `cy.exe()` command w/o using npm commands.
 - Bring the restore DB function to a centralized place (in commands.js file).
 
 Please review and merge. Thanks. 
 cc: @jayasanka-sack @ibacher @brandones 