### PR TITLE
Access Patient Chart through Patient searching

### DIFF
--- a/packages/cypress/cypress/integration/common/refapp-3.x/common.js
+++ b/packages/cypress/cypress/integration/common/refapp-3.x/common.js
@@ -9,5 +9,7 @@ Given('the user login to the Outpatient Clinic', () => {
   })
   
 And('the user arrives on a patient’s chart page', () => {
-    cy.visit(`patient/${patient.uuid}/chart`);
+    cy.get('button[name=SearchPatientIcon]').click();
+    cy.getByPlaceholder('Search for a patient by name or identifier number').type('John Doe')
+    cy.contains('John Doe').first().click({force: true});
 });


### PR DESCRIPTION
Originally we were using the uuid of the stored patient object created in the before hook to access the Patient Chart.  However, since we migrated all before hooks to their corresponding spec files, accessing the patient object is somewhat hard.

I have reverted to manually searching for the patient just like its done normally with the instance.