### PR TITLE
O3-1579: Fix failing tests due to invalid local

### DIFF
--- a/packages/cypress/cypress/support/commands.js
+++ b/packages/cypress/cypress/support/commands.js
@@ -51,7 +51,7 @@ Cypress.Commands.add('login', () => {
         url: `${API_BASE_URL}/session`,
         body: {
           sessionLocation: DEFAULT_LOCATION_UUID,
-          locale: "en_GB",
+          locale: "en",
         },
         headers: {
             'Content-Type': 'application/json',


### PR DESCRIPTION
## Purpose
This PR aims to fix failing tests due to invalid local provided during session creation. 

ex: https://github.com/openmrs/openmrs-test-3refapp/actions/runs/3390711229/jobs/5640159334

[Ticket](https://issues.openmrs.org/browse/O3-1579)
## Approach

- Change the locale to `en`
