### PR TITLE
fix broken link in the readme for sample workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Follow this steps for setting up the local instance
 
 
 ## Creating a GitHub workflow
-1. Create a new GitHub workflow file under `.github/workflows/` directory. An example workflow can be found [here](https://github.com/openmrs/openmrs-contrib-qaframework/blob/master/.github/workflows/refapp-3x-login.yml).
+1. Create a new GitHub workflow file under `.github/workflows/` directory. An example workflow can be found [here](https://github.com/ayush-AI/openmrs-test-3refapp/blob/main/.github/workflows/refapp-3x-login.yml).
 2. Add the workflow badge to the readme file under [3.x RefApp](https://github.com/openmrs/openmrs-test-3refapp/blob/main/README.md#qa-dashboard-for-refapp-3x-project-status) section. It should take the following format:
     ```markdown
     [![<workflow name>](<link-to-the-workflow>/badge.svg)](<link-to-the-workflow>)


### PR DESCRIPTION
## Purpose

I am opening this PR for fixing the broken link in the `Creating Workflow` section of the readme.

## Other
Please check the link which I am adding is referring to the desired sample